### PR TITLE
Rename project to 'MIGUEL - Chatbot didático' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 Pipeline RAG LangChain
+# 🚀 MIGUEL - Chatbot didático
 
 > ✨ **Pipeline didático de Retrieval-Augmented Generation (RAG)** construído com **LangChain** — focado em um pipeline *mínimo* e reproduzível: **HuggingFace embeddings → FAISS retriever → LLM local (FLAN‑T5)**, com fallback opcional para OpenAI. Ideal para ensinar conceitos modernos de RAG passo a passo.
 
@@ -105,8 +105,8 @@ flowchart TB
 
 ```bash
 # Clone o repositório
-git clone https://github.com/seu-usuario/pipeline-rag-langchain.git
-cd pipeline-rag-langchain
+git clone https://github.com/seu-usuario/miguel-chatbot-didatico.git
+cd "MIGUEL - Chatbot didático"
 
 # Crie ambiente virtual (opcional mas recomendado)
 python -m venv .venv
@@ -219,7 +219,7 @@ for pergunta, termo_esperado in perguntas_teste:
 ## 📁 Estrutura do Projeto
 
 ```
-pipeline-rag-langchain/
+MIGUEL - Chatbot didático/
 ├── 📁 config/                  # Configurações Hydra
 │   ├── main.yaml              # Configuração principal
 │   ├── model/                 # Parâmetros de modelos


### PR DESCRIPTION
### Motivation
- Align the repository documentation and quickstart instructions with the new project name by renaming the title and references to the project directory and clone path in `README.md`.

### Description
- Updated `README.md` to change the project title to "MIGUEL - Chatbot didático", replaced the quickstart `git clone` URL with `https://github.com/seu-usuario/miguel-chatbot-didatico.git`, updated the `cd` command to `cd "MIGUEL - Chatbot didático"`, and adjusted the example project tree name accordingly.

### Testing
- No automated tests were run because this is a documentation-only change to `README.md` (no code modifications).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba6c221ac8328a7c065b926bbbc03)