### PR TITLE
Rename project references to 'MIGUEL - Chatbot didático'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 Pipeline RAG LangChain
+# 🚀 MIGUEL - Chatbot didático
 
 > ✨ **Pipeline didático de Retrieval-Augmented Generation (RAG)** construído com **LangChain** — focado em um pipeline *mínimo* e reproduzível: **HuggingFace embeddings → FAISS retriever → LLM local (FLAN‑T5)**, com fallback opcional para OpenAI. Ideal para ensinar conceitos modernos de RAG passo a passo.
 
@@ -105,8 +105,8 @@ flowchart TB
 
 ```bash
 # Clone o repositório
-git clone https://github.com/seu-usuario/pipeline-rag-langchain.git
-cd pipeline-rag-langchain
+git clone https://github.com/seu-usuario/miguel-chatbot-didatico.git
+cd "MIGUEL - Chatbot didático"
 
 # Crie ambiente virtual (opcional mas recomendado)
 python -m venv .venv
@@ -131,7 +131,7 @@ export OPENAI_API_KEY=sk-...  # Windows PowerShell: $env:OPENAI_API_KEY="sk-..."
 jupyter notebook notebooks/pipeline_rag_langchain.ipynb
 
 # Ou abra diretamente no Google Colab
-# https://colab.research.google.com/github/seu-usuario/pipeline-rag-langchain/blob/main/notebooks/pipeline_rag_langchain.ipynb
+# https://colab.research.google.com/github/seu-usuario/miguel-chatbot-didatico/blob/main/notebooks/pipeline_rag_langchain.ipynb
 ```
 
 ---
@@ -219,7 +219,7 @@ for pergunta, termo_esperado in perguntas_teste:
 ## 📁 Estrutura do Projeto
 
 ```
-pipeline-rag-langchain/
+MIGUEL - Chatbot didático/
 ├── 📁 config/                  # Configurações Hydra
 │   ├── main.yaml              # Configuração principal
 │   ├── model/                 # Parâmetros de modelos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 
 [tool.poetry]
-name = "pipeline-rag-langchain"
+name = "miguel-chatbot-didatico"
 version = "0.1.0"
 description = ""
 authors = ["Bruno César Maymone Galvão"]


### PR DESCRIPTION
### Motivation
- Align documentation and packaging metadata with the new project name so links, quickstart instructions and tooling reflect the rename.
- Make the Colab link and example project tree point to the correct repository path (`seu-usuario/miguel-chatbot-didatico`) so the notebook can be opened directly.

### Description
- Updated `README.md` to rename the project title to "MIGUEL - Chatbot didático", update the `git clone` example to `https://github.com/seu-usuario/miguel-chatbot-didatico.git`, change the `cd` example to `cd "MIGUEL - Chatbot didático"`, and update the Google Colab link to the new repository path.
- Updated `pyproject.toml` to change the Poetry package `name` from `pipeline-rag-langchain` to `miguel-chatbot-didatico` so packaging metadata matches the rename.

### Testing
- No automated tests were run because this change only updates documentation and packaging metadata (`README.md` and `pyproject.toml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba6c221ac8328a7c065b926bbbc03)